### PR TITLE
 list_fw_tags(): returns array; set_fw_policy_base() added; added example script to clone firewall rules

### DIFF
--- a/aviatrix/__init__.py
+++ b/aviatrix/__init__.py
@@ -522,6 +522,96 @@ class Aviatrix(object):
             params['saml_endpoint'] = saml_endpoint
         self._avx_api_call('POST', 'attach_vpn_user', params)
 
+    def add_vpn_profile(self, profile_name, base_policy=None):
+        """
+        Adds a new VPN profile with the given name
+        Arguments:
+        profile_name - string - name of the new profile
+        base_policy - string - one of (deny_all, allow_all)
+        """
+
+        params = {'profile_name': profile_name,
+                  'base_policy': 'deny_all' if not base_policy else base_policy}
+        self._avx_api_call('GET', 'add_user_profile', params)
+
+    def delete_vpn_profile(self, profile_name):
+        """
+        Deletes an existing VPN profile with the given name
+        Arguments:
+        profile_name - string - name of the profile to delete
+        """
+
+        params = {'profile_name': profile_name}
+        self._avx_api_call('GET', 'del_user_profile', params)
+
+    def list_vpn_profile_policies(self, profile_name):
+        """
+        Gets a list of all policies associated with the given profile
+        Arguments:
+        profile_name - string - name of the profile
+        Returns:
+        array of dict containing:
+              'action' : 'allow', 'deny'
+              'protocol': 'all', 'tcp', 'udp', 'icmp', 'sctp', 'rdp', 'dccp'
+              'target': valid CIDR
+              'port': port or port range (for example, '25' or '25:1024')
+        """
+        params = {'profile_name': profile_name}
+        self._avx_api_call('GET', 'list_profile_policies', params)
+        if 'policies' in self.results:
+            return self.results['policies']
+        return []
+
+    def update_vpn_profile_policies(self, profile_name, policies):
+        """
+        Updates the policies associated with the given profile
+        Arguments:
+        profile_name - string - name of the profile to update
+        policies - array(dict) - array of objects containing
+              'action' : 'allow', 'deny'
+              'protocol': 'all', 'tcp', 'udp', 'icmp', 'sctp', 'rdp', 'dccp'
+              'target': valid CIDR
+              'port': port or port range (for example, '25' or '25:1024')
+        """
+
+        params = {'profile_name': profile_name,
+                  'policy': json.dumps(policies)}
+        self._avx_api_call('GET', 'update_profile_policy', params)
+
+    def add_vpn_profile_member(self, profile_name, username):
+        """
+        Adds a user to an existing profile
+        Arguments:
+        profile_name - string - name of an existing profile
+        username - string - name of an existing VPN user
+        """
+
+        params = {'profile_name': profile_name, 'username': username}
+        self._avx_api_call('GET', 'add_profile_member', params)
+
+    def delete_vpn_profile_member(self, profile_name, username):
+        """
+        Deletes a user from an existing profile
+        Arguments:
+        profile_name - string - name of an existing profile
+        username - string - name of an existing VPN user
+        """
+
+        params = {'profile_name': profile_name, 'username': username}
+        self._avx_api_call('GET', 'del_profile_member', params)
+
+    def list_vpn_profiles(self):
+        """
+        Lists all VPN profiles and their members
+        Returns:
+        dictionary(string => list). dictionary key is the profile name,
+                     value is a list of member usernames
+        """
+
+        params = {}
+        self._avx_api_call('GET', 'list_user_profile_names', params)
+        return self.results
+
     class StatName(object):
         """
         Enum representation for the statistic name field
@@ -762,8 +852,7 @@ class Aviatrix(object):
         self._avx_api_call('POST', 'list_policy_tags', params, True)
         if 'tags' in self.results:
             return self.results['tags']
-        else:
-            return []
+        return []
 
     def add_fw_tag(self, tag_name):
         """

--- a/examples/clone_fw_policies.py
+++ b/examples/clone_fw_policies.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+"""
+ This script provides an example of how to connect to 2 Aviatrix Controllers
+ and copy the firewall configuration from one to the other.
+
+ INPUTS:
+   $1 - SRC_USER::SRC_PASSWD@@SRC_HOST - string - host/ip and login details of the source controller
+   $2 - DST_USER::DST_PASSWD@@DST_HOST - string - host/ip and login details of the destination controller
+   $3 - SRC_GW - string - source gateway name to use
+   $3 - DST_GW - string - destination gateway name to use
+
+"""
+import logging
+import sys
+
+from aviatrix import Aviatrix
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def main():
+    """
+    main() interface to this script
+    """
+    if len(sys.argv) != 5:
+        print ('usage: %s <SRC_USER::SRC_PASSWD@@SRC_HOST> '
+               '<DEST_USER:DEST_PASSWD@DEST_HOST> SRC_GW DEST_GW\n'
+               '  where\n'
+               '    HOST Aviatrix Controller hostname or IP\n'
+               '    USER Aviatrix Controller login username\n'
+               '    PASSWORD Aviatrix Controller login password\n'
+               '    GW name of a provisioned gateway\n' % sys.argv[0])
+        sys.exit(1)
+
+    # connect to both controllers
+    src_controller = get_controller_from_argument(sys.argv[1])
+    dst_controller = get_controller_from_argument(sys.argv[2])
+
+    # find the source gateway
+    gw_name = sys.argv[3]
+    src_gwy = src_controller.get_gateway_by_name('admin', gw_name)
+    if not src_gwy:
+        print 'Source gateway %s not found\n' % (gw_name)
+        return
+
+    # find the destination gateway
+    gw_name = sys.argv[4]
+    dst_gwy = src_controller.get_gateway_by_name('admin', gw_name)
+    if not dst_gwy:
+        print 'Destination gateway %s not found\n' % (gw_name)
+        return
+
+    # clone the firewall policies and the FQDN filters
+    clone_fw_rules(src_controller, src_gwy, dst_controller, dst_gwy)
+    clone_fqdn_rules(src_controller, src_gwy, dst_controller, dst_gwy)
+
+def get_controller_from_argument(arg):
+    """
+    Gets an Aviatrix Controller object from a string of the format:
+         USER::PASSWD@@HOST
+    """
+
+    userpw, controller_host = arg.split('@@')
+    username, password = userpw.split('::')
+
+    logging.debug('Connecting to Aviatrix @ %s', controller_host)
+    controller = Aviatrix(controller_host)
+    controller.login(username, password)
+    return controller
+
+def clone_fw_rules(src_controller, src_gwy,
+                   dst_controller, dst_gwy):
+    """
+    Clone the firewall rules associated with the given gateway
+    Arguments:
+    src_controller - Aviatrix object - aviatrix controller (source)
+    src_gwy - Dictionary(aviatrix gateway) - aviatrix gateway object (source)
+    dst_controller - Aviatrix object - aviatrix controller (destination)
+    dst_gwy - Dictionary(aviatrix gateway) - aviatrix gateway obj (destination)
+    """
+
+    # STEP 1: clone fw tags
+    src_fw_tags = src_controller.list_fw_tags()
+    dst_fw_tags = dst_controller.list_fw_tags()
+    for tag in src_fw_tags:
+        if tag not in dst_fw_tags:
+            logging.info('Adding tag %s ...', tag)
+            dst_controller.add_fw_tag(tag)
+            members = src_controller.get_fw_tag_members(tag)
+            dst_controller.set_fw_tag_members(tag, members)
+        else:
+            logging.warn('FW tag \'%s\' already present in destination', tag)
+            # NOTE: it may be appropriate to match the members from the source
+            # with this destination so they match
+
+    # STEP 2: clone fw rules on gateway
+    src_policy = src_controller.get_fw_policy_full(src_gwy['vpc_name'])
+    dst_policy = dst_controller.get_fw_policy_full(dst_gwy['vpc_name'])
+
+    # base policy
+    # this is written to only update base_policy OR base_policy_log_enable
+    # due to a bug in the Aviatrix API.  Only one of these may be set at a time.
+    # So, we get the dest current value and compare with src value and update
+    # one of the values at once (if both changed)
+    if dst_policy['base_policy'] != src_policy['base_policy']:
+        logging.info('Updating firewall base policy to %s', src_policy['base_policy'])
+        dst_controller.set_fw_policy_base(dst_gwy['vpc_name'],
+                                          src_policy['base_policy'],
+                                          dst_policy['base_policy_log_enable'])
+        dst_policy = dst_controller.get_fw_policy_full(dst_gwy['vpc_name'])
+
+    if dst_policy['base_policy_log_enable'] != src_policy['base_policy_log_enable']:
+        logging.info('Updating firewall base log policy to %s',
+                     src_policy['base_policy_log_enable'])
+        dst_controller.set_fw_policy_base(dst_gwy['vpc_name'],
+                                          dst_policy['base_policy'],
+                                          src_policy['base_policy_log_enable'])
+
+    # set the rules
+    logging.info('Setting firewall rules ...')
+    dst_controller.set_fw_policy_security_rules(dst_gwy['vpc_name'],
+                                                src_policy['security_rules'])
+
+def clone_fqdn_rules(src_controller, src_gwy,
+                     dst_controller, dst_gwy):
+    """
+    Clone the firewall FQDN rules associated with the given gateway
+    Arguments:
+    src_controller - Aviatrix object - aviatrix controller (source)
+    src_gwy - Dictionary(aviatrix gateway) - aviatrix gateway object (source)
+    dst_controller - Aviatrix object - aviatrix controller (destination)
+    dst_gwy - Dictionary(aviatrix gateway) - aviatrix gateway obj (destination)
+    """
+
+    # make sure NAT is enabled
+    if dst_gwy['enable_nat'] != 'yes':
+        logging.info('Enabling NAT ...')
+        dst_controller.enable_nat(dst_gwy['vpc_name'])
+
+    # FQDN filters
+    src_tags = src_controller.list_fqdn_filters()
+    dst_tags = dst_controller.list_fqdn_filters()
+    for tag in src_tags.keys():
+        if tag not in dst_tags.keys():
+            src_tag_details = src_tags[tag]
+            logging.info('Adding FQDN filter tag %s ...', tag)
+            dst_controller.add_fqdn_filter_tag(tag)
+            domains = src_controller.get_fqdn_filter_domain_list(tag)
+            dst_controller.set_fqdn_filter_domain_list(tag, domains)
+            if src_tag_details['state'] == 'enabled':
+                dst_controller.enable_fqdn_filter(tag)
+
+        else:
+            logging.warn('FQDN Filter Tag %s already present in destination', tag)
+            # NOTE: it may be appropriate to update the domains associated
+            # with this filter so it matches the source
+
+if __name__ == "__main__":
+    main()

--- a/examples/clone_fw_policies.py
+++ b/examples/clone_fw_policies.py
@@ -148,7 +148,8 @@ def clone_fqdn_rules(src_controller, src_gwy,
             dst_controller.set_fqdn_filter_domain_list(tag, domains)
             if src_tag_details['state'] == 'enabled':
                 dst_controller.enable_fqdn_filter(tag)
-
+            # NOTE: it may be appropriate to attach the gateway to the tags
+            # here also
         else:
             logging.warn('FQDN Filter Tag %s already present in destination', tag)
             # NOTE: it may be appropriate to update the domains associated

--- a/examples/update_vpn_profiles.py
+++ b/examples/update_vpn_profiles.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+"""
+# This script provides an example of how to connect to an Aviatrix Controller
+# and update user vpn profiles
+#
+# INPUTS:
+#   $1 - HOST - string - host/ip of the controller
+#   $2 - USER - string - the username used to authenticate with controller
+#   $3 - PASSWORD - string - the password of the given USER
+#
+"""
+
+import logging
+import sys
+
+from aviatrix import Aviatrix
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def main():
+    """
+    main() interface to this script
+    """
+    if len(sys.argv) != 4:
+        print ('usage: %s <HOST> <USER> <PASSWORD>\n'
+               '  where\n'
+               '    HOST Aviatrix Controller hostname or IP\n'
+               '    USER Aviatrix Controller login username\n'
+               '    PASSWORD Aviatrix Controller login password\n' % sys.argv[0])
+        sys.exit(1)
+
+    # connect to the controller
+    controller_ip = sys.argv[1]
+    username = sys.argv[2]
+    password = sys.argv[3]
+    controller = Aviatrix(controller_ip)
+    controller.login(username, password)
+
+    create_profiles(controller)
+    attach_users(controller)
+    detach_users(controller)
+    cleanup_profiles(controller)
+
+def create_profiles(controller):
+    """
+    Creates the profiles required
+    Arguments:
+    controller - reference to Aviatrix Controller
+    """
+
+    current = controller.list_vpn_profiles()
+    print 'CURRENT: %s' % (current)
+
+    if 'TEST1' not in current.keys():
+        controller.add_vpn_profile('TEST1')
+    current = controller.list_vpn_profile_policies('TEST1')
+    print 'POLICIES: %s' % (current)
+    policies = [
+        {'action': 'allow', 'protocol': 'all', 'target': '10.0.0.0/24', 'port': '0:1024'},
+        {'action': 'allow', 'protocol': 'tcp', 'target': '192.168.0.0/24', 'port': '22'},
+        {'action': 'deny', 'protocol': 'all', 'target': '172.16.0.0/24', 'port': '0:1024'}
+    ]
+    controller.update_vpn_profile_policies('TEST1', policies)
+    current = controller.list_vpn_profile_policies('TEST1')
+    print 'POLICIES: %s' % (current)
+    controller.add_vpn_profile('TEST2', 'allow_all')
+    controller.add_vpn_profile('TEST3', 'deny_all')
+
+    current = controller.list_vpn_profiles()
+    print 'AFTER: %s' % (current)
+
+def attach_users(controller):
+    """
+    Attach users to profiles
+    """
+
+    controller.add_vpn_profile_member('TEST1', 'test2')
+    controller.add_vpn_profile_member('TEST2', 'test3')
+    controller.add_vpn_profile_member('TEST3', 'test3')
+
+def detach_users(controller):
+    """
+    Detachs users created with attach_users
+    """
+    controller.delete_vpn_profile_member('TEST1', 'test2')
+    controller.delete_vpn_profile_member('TEST2', 'test3')
+    controller.delete_vpn_profile_member('TEST3', 'test3')
+
+def cleanup_profiles(controller):
+    """
+    Cleans up the profiles created by create_profiles()
+    Arguments:
+    controller - reference to the Aviatrix Controller
+    """
+
+    controller.delete_vpn_profile('TEST1')
+    controller.delete_vpn_profile('TEST2')
+    controller.delete_vpn_profile('TEST3')
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='aviatrix-sdk',
-    version='0.7',
+    version='0.8',
     description='Aviatrix Python SDK',
     long_description='Aviatrix Python SDK for automating Aviatrix Controller.',
     author='Aviatrix Solution Architects',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='aviatrix-sdk',
-    version='0.6',
+    version='0.7',
     description='Aviatrix Python SDK',
     long_description='Aviatrix Python SDK for automating Aviatrix Controller.',
     author='Aviatrix Solution Architects',


### PR DESCRIPTION
list_fw_tags()
  - now returns the array of tags rather than a dictionary

set_fw_policy_base()
  - added to support setting the base policy and base logging

examples/clone_fw_policies.py
  - added example to show how to clone firewall rules (both fw and fqdn)

add_vpn_profile(),  delete_vpn_profile(), list_vpn_profile_policies(), update_vpn_profile_policies(), add_vpn_profile_member(), delete_vpn_profile_member(), list_vpn_profiles()
  - support for user vpn profile APIs added

examples/update_vpn_profiles.py
  - added example to show how to update VPN profiles
